### PR TITLE
Fixed Some OS X directory paths

### DIFF
--- a/pseuthe/Pseuthe-Info.plist
+++ b/pseuthe/Pseuthe-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIconFile</key>
-	<string></string>
+	<string>Pseuthe_OSX_Icon</string>
 	<key>CFBundleIdentifier</key>
 	<string>Pseuthe.${PRODUCT_NAME:rfc1034identifier}</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/pseuthe/include/Log.hpp
+++ b/pseuthe/include/Log.hpp
@@ -45,6 +45,10 @@ source distribution.
 #include <Windows.h>
 #endif //_MSC_VER
 
+//Needed to access resources on OS X
+#ifdef __APPLE__
+#include <ResourcePath.hpp>
+#endif
 
 class Logger final
 {
@@ -97,8 +101,14 @@ public:
         }
         if (output == Output::File || output == Output::All)
         {
+            std::string resPath("");
+            //if it's OS X, prepend the resourcePath
+            #ifdef __APPLE__
+            resPath = resourcePath();
+            #endif
+            
             //output to a log file
-            std::ofstream file("output.log", std::ios::app);
+            std::ofstream file(resPath + "output.log", std::ios::app);
             if (file.good())
             { 
                 file << outstring << std::endl;

--- a/pseuthe/src/App.cpp
+++ b/pseuthe/src/App.cpp
@@ -41,6 +41,11 @@ source distribution.
 #include <fstream>
 #include <cstring>
 
+//Needed to access resources on OS X
+#ifdef __APPLE__
+#include <ResourcePath.hpp>
+#endif
+
 using namespace std::placeholders;
 
 namespace
@@ -332,7 +337,13 @@ void App::registerStates()
 
 void App::loadSettings()
 {
-    std::fstream file(settingsFile, std::ios::binary | std::ios::in);
+    //OS X Resource Path
+    std::string resPath("");
+    #ifdef __APPLE__
+    resPath = resourcePath();
+    #endif
+    
+    std::fstream file(resPath + settingsFile, std::ios::binary | std::ios::in);
     if (!file.good() || !file.is_open() || file.fail())
     {
         Logger::Log("failed to open settings file for reading", Logger::Type::Warning, Logger::Output::All);
@@ -377,7 +388,13 @@ void App::loadSettings()
 
 void App::saveSettings()
 {
-    std::fstream file(settingsFile, std::ios::binary | std::ios::out);
+    //OS X Resource Path
+    std::string resPath("");
+    #ifdef __APPLE__
+    resPath = resourcePath();
+    #endif
+    
+    std::fstream file(resPath + settingsFile, std::ios::binary | std::ios::out);
     if (!file.good() || !file.is_open() || file.fail())
     {
         Logger::Log("failed to open settings file for writing", Logger::Type::Error, Logger::Output::All);
@@ -411,7 +428,14 @@ void App::saveScreenshot()
     strftime(buffer, 40, "screenshot%d_%m_%y_%H_%M_%S.png", timeInfo);
 
     fileName.assign(buffer);
+    
+    //get the "Pictures" folder if we are on OS X
+    //as we can't save to working directory (which would be "Applications")
+    #ifdef __APPLE__
+    std::string user = getenv("USER");
+    std::string picturesPath = "/Users/" + user + "/Pictures/";
+    #endif
 
     sf::Image screenCap = m_renderWindow.capture();
-    if (!screenCap.saveToFile(fileName)) Logger::Log("failed to save " + fileName, Logger::Type::Error, Logger::Output::File);
+    if (!screenCap.saveToFile(picturesPath + fileName)) Logger::Log("failed to save " + fileName, Logger::Type::Error, Logger::Output::File);
 }

--- a/pseuthe/src/App.cpp
+++ b/pseuthe/src/App.cpp
@@ -431,9 +431,10 @@ void App::saveScreenshot()
     
     //get the "Pictures" folder if we are on OS X
     //as we can't save to working directory (which would be "Applications")
+    std::string picturesPath("");
     #ifdef __APPLE__
     std::string user = getenv("USER");
-    std::string picturesPath = "/Users/" + user + "/Pictures/";
+    picturesPath = "/Users/" + user + "/Pictures/";
     #endif
 
     sf::Image screenCap = m_renderWindow.capture();

--- a/pseuthe/src/Score.cpp
+++ b/pseuthe/src/Score.cpp
@@ -34,6 +34,11 @@ source distribution.
 #include <algorithm>
 #include <functional>
 
+//Needed to access resources on OS X
+#ifdef __APPLE__
+#include <ResourcePath.hpp>
+#endif
+
 namespace
 {
     const int ident = 0x534e5542;
@@ -44,7 +49,13 @@ namespace
 
 void Scores::load()
 {
-    std::fstream file(scoreFile, std::ios::binary | std::ios::in);
+    //OS X Resource Path
+    std::string resPath("");
+    #ifdef __APPLE__
+    resPath = resourcePath();
+    #endif
+    
+    std::fstream file(resPath + scoreFile, std::ios::binary | std::ios::in);
     if (!file.good() || !file.is_open() || file.fail())
     {
         Logger::Log("failed to open score data for reading", Logger::Type::Warning, Logger::Output::All);
@@ -88,7 +99,13 @@ void Scores::load()
 
 void Scores::save()
 {
-    std::fstream file(scoreFile, std::ios::binary | std::ios::out);
+    //OS X Resource Path
+    std::string resPath("");
+    #ifdef __APPLE__
+    resPath = resourcePath();
+    #endif
+    
+    std::fstream file(resPath + scoreFile, std::ios::binary | std::ios::out);
     if (!file.good() || !file.is_open() || file.fail())
     {
         Logger::Log("failed to open score data for writing", Logger::Type::Error, Logger::Output::All);


### PR DESCRIPTION
Fixed up path’s for settings, scores and logs so they go in the
resource folder. Screenshots will go to the users “Pictures” folder.
plist file change adds the icons to the project which I missed in
previous commit
